### PR TITLE
sepolicy_vndr: Fix qtr_sdk_use macro definition

### DIFF
--- a/generic/vendor/kona/te_macros
+++ b/generic/vendor/kona/te_macros
@@ -33,7 +33,7 @@
 #######################################
 # Allow domains to use QTR SDK for metric collection
 # syntax: qtr_sdk_use(clientdomain)
-define(`qtr_sdk_use',
+define(`qtr_sdk_use',`
 # qtrsdkservice client for registering & start/stop campaign
 allow $1 vendor_qtrsdkservice_service:service_manager find;
 binder_call($1, vendor_qcc_trd)


### PR DESCRIPTION
Fixes: qvrd_vndr.te:36:WARNING 'unrecognized character'